### PR TITLE
Add kata 'List Ops'

### DIFF
--- a/list-ops/.eslintrc
+++ b/list-ops/.eslintrc
@@ -1,0 +1,26 @@
+{
+  "root": true,
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaVersion": 7,
+    "sourceType": "module"
+  },
+  "env": {
+    "es6": true,
+    "node": true,
+    "jest": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:import/errors",
+    "plugin:import/warnings"
+  ],
+  "rules": {
+    "linebreak-style": "off",
+
+    "import/extensions": "off",
+    "import/no-default-export": "off",
+    "import/no-unresolved": "off",
+    "import/prefer-default-export": "off"
+  }
+}

--- a/list-ops/.meta/HINTS.md
+++ b/list-ops/.meta/HINTS.md
@@ -1,0 +1,1 @@
+Using core language features to build and deconstruct arrays via destructuring, and using the array literal `[]` are allowed, but no functions from the `Array.prototype` should be used.

--- a/list-ops/README.md
+++ b/list-ops/README.md
@@ -1,0 +1,54 @@
+# List Ops
+
+Implement basic list operations.
+
+In functional languages list operations like `length`, `map`, and
+`reduce` are very common. Implement a series of basic list operations,
+without using existing functions.
+
+The precise number and names of the operations to be implemented will be 
+track dependent to avoid conflicts with existing names, but the general
+operations you will implement include:
+
+* `append` (*given two lists, add all items in the second list to the end of the first list*);
+* `concatenate` (*given a series of lists, combine all items in all lists into one flattened list*);
+* `filter` (*given a predicate and a list, return the list of all items for which `predicate(item)` is True*);
+* `length` (*given a list, return the total number of items within it*);
+* `map` (*given a function and a list, return the list of the results of applying `function(item)` on all items*);
+* `foldl` (*given a function, a list, and initial accumulator, fold (reduce) each item into the accumulator from the left using `function(accumulator, item)`*);
+* `foldr` (*given a function, a list, and an initial accumulator, fold (reduce) each item into the accumulator from the right using `function(item, accumulator)`*);
+* `reverse` (*given a list, return a list with all the original items, but in reversed order*);
+
+## Setup
+
+Go through the setup instructions for Javascript to install the necessary
+dependencies:
+
+[https://exercism.io/tracks/javascript/installation](https://exercism.io/tracks/javascript/installation)
+
+## Requirements
+
+Install assignment dependencies:
+
+```bash
+$ npm install
+```
+
+## Making the test suite pass
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+In the test suites all tests but the first have been skipped.
+
+Once you get a test passing, you can enable the next one by changing `xtest` to
+`test`.
+
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have
+completed the exercise.

--- a/list-ops/babel.config.js
+++ b/list-ops/babel.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  presets: [
+    [
+      '@babel/env',
+      {
+        targets: {
+          node: 'current',
+        },
+        useBuiltIns: false,
+      },
+
+    ],
+  ],
+};

--- a/list-ops/example.js
+++ b/list-ops/example.js
@@ -1,0 +1,95 @@
+const Null = {
+  get value() { return undefined },
+  get next() { return this },
+  get values() { return [] },
+
+  get() { return this.value },
+  push(item) { return new Cons(item, this) },
+  length() { return 0 },
+  append(other) { return other },
+  concat() { return this },
+  forEach() { /* done */ },
+  foldl(_, initial) { return initial },
+  foldr(_, initial) { return initial },
+  filter() { return Null },
+  reverse() { return this },
+  map() { return this },
+}
+
+class Cons {
+  static fromArray([head, ...tail]) {
+    if (head === undefined) {
+      return Null
+    }
+
+    return new Cons(head, Cons.fromArray(tail || []))
+  }
+
+  constructor(value, next = Null) {
+    this.value = value
+    this.next = next
+  }
+
+  get values() {
+    return [this.value, ...this.next.values]
+  }
+
+  get(i) {
+    return i === 0
+      ? this.value
+      : this.next.get(i - 1)
+  }
+
+  push(item) {
+    this.next = this.next.push(item)
+    return this
+  }
+
+  length() {
+    return 1 + this.next.length()
+  }
+
+  append(other) {
+    return other.foldl((result, item) => result.push(item), this)
+  }
+
+  concat(others) {
+    return others.foldl((result, other) => result.append(other), this)
+  }
+
+  foldl(callback, initial = undefined) {
+    return this.next.foldl(callback, callback(initial, this.value))
+  }
+
+  forEach(callback) {
+    this.foldl((_, item) => callback(item))
+  }
+
+  foldr(callback, initial = undefined) {
+    return callback(this.next.foldr(callback, initial), this.value)
+  }
+
+  filter(predicate) {
+    return this.foldl(
+      (result, item) => (predicate(item) && result.push(item)) || result,
+      Null,
+    )
+  }
+
+  map(expression) {
+    return this.foldl(
+      (result, item) => result.push(expression(item)),
+      Null,
+    )
+  }
+
+  reverse() {
+    return this.next.reverse().push(this.value)
+  }
+}
+
+export class List {
+  constructor(values = []) {
+    return Cons.fromArray(values)
+  }
+}

--- a/list-ops/list-ops.spec.js
+++ b/list-ops/list-ops.spec.js
@@ -1,0 +1,117 @@
+import { List } from './list-ops';
+
+describe('append entries to a list and return the new list', () => {
+  test('empty lists', () => {
+    const list1 = new List();
+    const list2 = new List();
+    expect(list1.append(list2)).toEqual(new List());
+  });
+
+  xtest('empty list to list', () => {
+    const list1 = new List([1, 2, 3, 4]);
+    const list2 = new List();
+    expect(list1.append(list2)).toEqual(list1);
+  });
+
+  xtest('non-empty lists', () => {
+    const list1 = new List([1, 2]);
+    const list2 = new List([2, 3, 4, 5]);
+    expect(list1.append(list2).values).toEqual([1, 2, 2, 3, 4, 5]);
+  });
+});
+
+
+describe('concat lists and lists of lists into new list', () => {
+  xtest('empty list', () => {
+    const list1 = new List();
+    const list2 = new List();
+    expect(list1.concat(list2).values).toEqual([]);
+  });
+
+  xtest('list of lists', () => {
+    const list1 = new List([1, 2]);
+    const list2 = new List([3]);
+    const list3 = new List([]);
+    const list4 = new List([4, 5, 6]);
+    const listOfLists = new List([list2, list3, list4])
+    expect(list1.concat(listOfLists).values).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+});
+
+
+describe('filter list returning only values that satisfy the filter function', () => {
+  xtest('empty list', () => {
+    const list1 = new List([]);
+    expect(list1.filter(el => el % 2 === 1).values).toEqual([]);
+  });
+
+  xtest('non empty list', () => {
+    const list1 = new List([1, 2, 3, 5]);
+    expect(list1.filter(el => el % 2 === 1).values).toEqual([1, 3, 5]);
+  });
+});
+
+
+describe('returns the length of a list', () => {
+  xtest('empty list', () => {
+    const list1 = new List();
+    expect(list1.length()).toEqual(0);
+  });
+
+  xtest('non-empty list', () => {
+    const list1 = new List([1, 2, 3, 4]);
+    expect(list1.length()).toEqual(4);
+  });
+});
+
+
+describe('returns a list of elements whose values equal the list value transformed by the mapping function', () => {
+  xtest('empty list', () => {
+    const list1 = new List();
+    expect(list1.map(el => ++el).values).toEqual([]);
+  });
+
+  xtest('non-empty list', () => {
+    const list1 = new List([1, 3, 5, 7]);
+    expect(list1.map(el => ++el).values).toEqual([2, 4, 6, 8]);
+  });
+});
+
+
+describe('folds (reduces) the given list from the left with a function', () => {
+  xtest('empty list', () => {
+    const list1 = new List();
+    expect(list1.foldl((acc, el) => el / acc, 2)).toEqual(2);
+  });
+
+  xtest('division of integers', () => {
+    const list1 = new List([1, 2, 3, 4]);
+    expect(list1.foldl((acc, el) => el / acc, 24)).toEqual(64);
+  });
+});
+
+
+describe('folds (reduces) the given list from the right with a function', () => {
+  xtest('empty list', () => {
+    const list1 = new List();
+    expect(list1.foldr((acc, el) => el / acc, 2)).toEqual(2);
+  });
+
+  xtest('division of integers', () => {
+    const list1 = new List([1, 2, 3, 4]);
+    expect(list1.foldr((acc, el) => el / acc, 24)).toEqual(9);
+  });
+});
+
+
+describe('reverse the elements of a list', () => {
+  xtest('empty list', () => {
+    const list1 = new List();
+    expect(list1.reverse().values).toEqual([]);
+  });
+
+  xtest('non-empty list', () => {
+    const list1 = new List([1, 3, 5, 7]);
+    expect(list1.reverse().values).toEqual([7, 5, 3, 1]);
+  });
+});

--- a/list-ops/package.json
+++ b/list-ops/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "exercism-javascript",
+  "version": "0.0.0",
+  "description": "Exercism exercises in Javascript.",
+  "author": "Katrina Owen",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/exercism/javascript"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.2.3",
+    "@babel/core": "^7.4.0",
+    "@babel/preset-env": "^7.4.2",
+    "babel-eslint": "^10.0.1",
+    "babel-jest": "^24.5.0",
+    "eslint": "^5.15.3",
+    "eslint-plugin-import": "^2.16.0",
+    "jest": "^24.5.0"
+  },
+  "jest": {
+    "modulePathIgnorePatterns": [
+      "package.json"
+    ]
+  },
+  "scripts": {
+    "test": "jest --no-cache ./*",
+    "watch": "jest --no-cache --watch ./*",
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
+  },
+  "license": "MIT",
+  "dependencies": {}
+}


### PR DESCRIPTION
This adds the "list-ops" kata to the `lunch_n_code_kata` repository so that Think company developers can download it without having to install the entire Exercism system.